### PR TITLE
add openai pr reviewer workflow

### DIFF
--- a/.github/workflows/openai-pr-reviewer.yml
+++ b/.github/workflows/openai-pr-reviewer.yml
@@ -1,0 +1,29 @@
+name: Code Review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group:
+    ${{ github.repository }}-${{ github.event.number || github.head_ref ||
+    github.sha }}-${{ github.workflow }}-${{ github.event_name ==
+    'pull_request_review_comment' && 'pr_comment' || 'pr' }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request_review_comment' }}
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fluxninja/openai-pr-reviewer@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        with:
+          debug: false
+          review_comment_lgtm: false


### PR DESCRIPTION
Hey @RashulChutani, looping you in on this, I figured you would be best suited to give an approval since you're managing the repos workflows. Basically, this [repo](https://github.com/fluxninja/openai-pr-reviewer) allows integrating a Github workflow to introduce a ChatGPT-powered PR reviewer to any repo. Mentioned this in Discord and Dan suggested we give it a try to see if the engineers find it useful. I added the `yml` file needed but I'm not sure where / how to set up the required secrets, namely:
 
_Environment variables_
- _GITHUB_TOKEN: This should already be available to the GitHub Action environment. This is used to add comments to the pull request._
- _OPENAI_API_KEY: use this to authenticate with OpenAI API. You can get one [here](https://platform.openai.com/account/api-keys). Please add this key to your GitHub Action secrets._
- _OPENAI_API_ORG: (optional) use this to use the specified organisation with OpenAI API if you have multiple. Please add this key to your GitHub Action secrets._ 

Could you give this a look ? I'm guessing it should be relatively fast to set up but no rush of course, feel free to drop this at the bottom of your list, thanks !