### PR TITLE
change check_fill_value_and_dtype_are_compatible

### DIFF
--- a/ivy/utils/assertions.py
+++ b/ivy/utils/assertions.py
@@ -196,14 +196,14 @@ def check_fill_value_and_dtype_are_compatible(fill_value, dtype):
     if (
         not (
             (ivy.is_int_dtype(dtype) or ivy.is_uint_dtype(dtype))
-            and (isinstance(fill_value, int) or ivy.isinf(fill_value))
+            and (isinstance(fill_value, (int,float,bool)) or ivy.isinf(fill_value))
         )
         and not (
             ivy.is_complex_dtype(dtype) and isinstance(fill_value, (float, complex))
         )
         and not (
             ivy.is_float_dtype(dtype)
-            and isinstance(fill_value, (float, np.float32))
+            and isinstance(fill_value, (float, np.float32,int,bool))
             or isinstance(fill_value, bool)
         )
     ):


### PR DESCRIPTION
<!-- 
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

## PR Description 

<!-- 
If there is no related issue, please add a short description about your PR.
-->



`a=jax.numpy.full((2,3),-34,dtype=bool)`
The above line works fine in JAX but would have failed with Ivy. Similarly, other cases (non-exhaustively) of dtype and fill_value being castable are handled. 

Requesting a review from Ved as he seems to have worked on this assertion and my "quick fix" might have consequences.

