### PR TITLE
refactor(ivy.linear): remove unneeded list()

### DIFF
--- a/ivy/functional/ivy/layers.py
+++ b/ivy/functional/ivy/layers.py
@@ -187,7 +187,7 @@ def linear(
     num_outer_batch_dims = len(outer_batch_shape)
     inner_batch_shape = list(x.shape[num_outer_batch_dims:-1])
     num_inner_batch_dims = len(inner_batch_shape)
-    num_out_feats, num_in_feats = list(weight.shape[-2:])
+    num_out_feats, num_in_feats = weight.shape[-2], weight.shape[-1]
 
     # OBS x IBS x OF
     y = ivy.matmul(


### PR DESCRIPTION
# PR Description

We had an unneeded list() call, I also got rid of the slice since for two values it seemed unneeded to me at least (plus you are creating a new list with a slice operation)

## Related Issue

No related issue

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
