### PR TITLE
feat(paddle-frontend): add `is_empty` API to resolve unresolved reference

### DIFF
--- a/ivy/functional/frontends/paddle/logic.py
+++ b/ivy/functional/frontends/paddle/logic.py
@@ -5,6 +5,7 @@ from ivy.func_wrapper import (
     with_unsupported_dtypes,
     handle_out_argument,
     with_supported_dtypes,
+    with_supported_device_and_dtypes,
 )
 from ivy.functional.frontends.paddle.func_wrapper import (
     to_ivy_arrays_and_back,
@@ -153,12 +154,21 @@ def greater_than(x, y, /, *, name=None):
     return ivy.greater(x, y)
 
 
-@with_unsupported_dtypes(
-    {"2.5.1 and below": ("uint8", "int8", "int16", "complex64", "complex128")}, "paddle"
+@with_supported_device_and_dtypes(
+    {
+        "2.5.1 and below": {
+            "cpu": ("int32", "int64", "float32", "float64"),
+            "gpu": ("int32", "int64", "float32", "float64"),
+        }
+    },
+    "paddle",
 )
 @to_ivy_arrays_and_back
 def is_empty(x, name=None):
-    return ivy.is_empty(x)
+    # handle scalar values
+    if len(x.shape) == 0:
+        return False
+    return any(dim == 0 for dim in x.shape)
 
 
 @to_ivy_arrays_and_back

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_logic.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_logic.py
@@ -291,14 +291,11 @@ def test_paddle_greater_than(
     )
 
 
+# is_empty
 @handle_frontend_test(
     fn_tree="paddle.is_empty",
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("valid"),
-        num_arrays=2,
-        shared_dtype=True,
-        safety_factor_scale="log",
-        small_abs_safety_factor=32,
     ),
 )
 def test_paddle_is_empty(


### PR DESCRIPTION
# PR Description

Previously, there was a call to `ivy.is_empty` in ivy's codebase which was not available. This commit adds the `is_empty` API to the `paddle` frontends, resolving this issue.


## Related Issue

Closes #26956

## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?



