### PR TITLE
fix: Fixed order of functions and added missing `staticmethod` decorator

### DIFF
--- a/ivy/data_classes/container/experimental/creation.py
+++ b/ivy/data_classes/container/experimental/creation.py
@@ -1252,57 +1252,6 @@ class _ContainerWithCreationExperimental(ContainerBase):
             map_sequences=map_sequences,
         )
 
-    def static_polyval(
-        coeffs: ivy.Container,
-        x: Union[ivy.Container, int, float],
-        *,
-        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
-        to_apply: bool = True,
-        prune_unapplied: bool = False,
-        map_sequences: bool = False,
-    ) -> ivy.Container:
-        r"""
-        ivy.Container static method variant of ivy.polyval. This method simply wraps the
-        function, and so the docstring for ivy.polyval also applies to this method with
-        minimal changes.
-
-        Evaluate and return a polynomial at specific given values.
-
-        Parameters
-        ----------
-        coeffs
-            Polynomial coefficients (including zero) from highest degree
-            to constant term.
-        x
-            The value of the indeterminate variable at which to evaluate the polynomial.
-        key_chains
-            The key-chains to apply or not apply the method to. Default is ``None``.
-        to_apply
-            If True, the method will be applied to key_chains, otherwise key_chains
-            will be skipped. Default is ``True``.
-        prune_unapplied
-            Whether to prune key_chains for which the function was not applied.
-            Default is ``False``.
-        map_sequences
-            Whether to also map method to sequences (lists, tuples).
-            Default is ``False``.
-
-        Returns
-        -------
-        ret
-            Output container containing simplified result of substituting x in the
-            coefficients - final value of polynomial.
-        """
-        return ContainerBase.cont_multi_map_in_function(
-            "polyval",
-            coeffs,
-            x,
-            key_chains=key_chains,
-            to_apply=to_apply,
-            prune_unapplied=prune_unapplied,
-            map_sequences=map_sequences,
-        )
-
     def unsorted_segment_mean(
         self: ivy.Container,
         segment_ids: Union[ivy.Array, ivy.Container],
@@ -1359,6 +1308,58 @@ class _ContainerWithCreationExperimental(ContainerBase):
             num_segments,
         )
 
+    @staticmethod
+    def static_polyval(
+        coeffs: ivy.Container,
+        x: Union[ivy.Container, int, float],
+        *,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+    ) -> ivy.Container:
+        r"""
+        ivy.Container static method variant of ivy.polyval. This method simply wraps the
+        function, and so the docstring for ivy.polyval also applies to this method with
+        minimal changes.
+
+        Evaluate and return a polynomial at specific given values.
+
+        Parameters
+        ----------
+        coeffs
+            Polynomial coefficients (including zero) from highest degree
+            to constant term.
+        x
+            The value of the indeterminate variable at which to evaluate the polynomial.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
+
+        Returns
+        -------
+        ret
+            Output container containing simplified result of substituting x in the
+            coefficients - final value of polynomial.
+        """
+        return ContainerBase.cont_multi_map_in_function(
+            "polyval",
+            coeffs,
+            x,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+        )
+
     def polyval(
         self: ivy.Container,
         coeffs: ivy.Container,
@@ -1388,4 +1389,4 @@ class _ContainerWithCreationExperimental(ContainerBase):
             Output container containing simplified result of substituting x in the
             coefficients - final value of polynomial.
         """
-        return self.static_polyval(self, coeffs, x)
+        return self.static_polyval(coeffs, x)


### PR DESCRIPTION
# PR Description
In the file [`ivy\data_classes\container\experimental\creation.py`](https://github.com/unifyai/ivy/blob/main/ivy/data_classes/container/experimental/creation.py):
The following functions are in wrong order:
https://github.com/unifyai/ivy/blob/6a7517784ea9c062b3735def4bb81c10d8989078/ivy/data_classes/container/experimental/creation.py#L1204
https://github.com/unifyai/ivy/blob/6a7517784ea9c062b3735def4bb81c10d8989078/ivy/data_classes/container/experimental/creation.py#L1255
https://github.com/unifyai/ivy/blob/6a7517784ea9c062b3735def4bb81c10d8989078/ivy/data_classes/container/experimental/creation.py#L1306
https://github.com/unifyai/ivy/blob/6a7517784ea9c062b3735def4bb81c10d8989078/ivy/data_classes/container/experimental/creation.py#L1362

Also, the `@staticmethod` decorator is missing for the `def static_polyval()` function and in the following function call 3 positional arguments should not be passed:
https://github.com/unifyai/ivy/blob/6a7517784ea9c062b3735def4bb81c10d8989078/ivy/data_classes/container/experimental/creation.py#L1391

## Related Issue
Closes #27435

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
