### PR TITLE
fix: Fixed using `callable` to check if x is callable instead of `hasattr`

### DIFF
--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -627,13 +627,13 @@ def test_default(x, default_val, test_flags, backend_fw):
     with BackendHandler.update_backend(backend_fw) as ivy_backend:
         with_callable = False
         if x is not None:
-            if hasattr(x, "__call__"):
+            if callable(x):
                 with_callable = True
             else:
                 x_dtype, x = x
                 x = x[0].tolist() if isinstance(x, list) else x
         else:
-            if hasattr(default_val, "__call__"):
+            if callable(default_val):
                 with_callable = True
             else:
                 dv_dtype, default_val = default_val
@@ -845,7 +845,7 @@ def test_einops_repeat(
 )
 def test_exists(x):
     if x is not None:
-        if not hasattr(x, "__call__"):
+        if not callable(x):
             dtype, x = x
     ret = ivy.exists(x)
     assert isinstance(ret, bool)


### PR DESCRIPTION
# PR Description
In some places `hasattr` is used to test if an object is `callable` but it is not always ideal because it only checks if the object has a particular attribute, but it doesn't ensure that the attribute is callable.
using `callable(obj)` to test if an obj is callable is a better approach.
https://github.com/unifyai/ivy/blob/36ec24a98f8a77ed39dc181fc2c21b2ffbe4449f/ivy_tests/test_ivy/test_functional/test_core/test_general.py#L630
https://github.com/unifyai/ivy/blob/36ec24a98f8a77ed39dc181fc2c21b2ffbe4449f/ivy_tests/test_ivy/test_functional/test_core/test_general.py#L636
https://github.com/unifyai/ivy/blob/36ec24a98f8a77ed39dc181fc2c21b2ffbe4449f/ivy_tests/test_ivy/test_functional/test_core/test_general.py#L848
I used [`ruff`](https://docs.astral.sh/ruff/) linter to find this.

## Related Issue
Closes #27446 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
