### PR TITLE
fix: Fixed default value of `os.getenv` 

### DIFF
--- a/ivy_tests/conftest.py
+++ b/ivy_tests/conftest.py
@@ -109,7 +109,7 @@ def pytest_configure(config):
     max_examples = getopt("--num-examples")
     deadline = getopt("--deadline")
     if (
-        os.getenv("REDIS_URL", default=False)
+        os.getenv("REDIS_URL", default=None)
         and os.environ["REDIS_URL"]
         and is_db_available(
             master=True,


### PR DESCRIPTION
# PR Description
The default value for `os.getenv` should be a  `string` or `None`, Otherwise it will be inconsistent with the [return type of `os.getenv`](https://docs.python.org/3/library/os.html#os.getenv).
This can cause errors.

If an environment variable is set, `os.getenv` will return its value as a string. If the environment variable is not set, `os.getenv` will return `None`, or the default value if one is provided. So, I guess the default value should be provided as `None`.

https://github.com/unifyai/ivy/blob/71b684745d403d290db4b5c5798cc5204ce9a22f/ivy_tests/conftest.py#L112


## Related Issue
Closes #27449 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
