### PR TITLE
fix: Fixed raising `broad exceptions` at few places.

### DIFF
--- a/ivy/data_classes/nested_array/base.py
+++ b/ivy/data_classes/nested_array/base.py
@@ -128,7 +128,9 @@ class NestedArrayBase(abc.ABC):
             return inspect_fn(*a, **kw)
 
         if num_nest == 0:
-            raise Exception(f"No RaggedArrays found in args or kwargs of function {fn}")
+            raise ValueError(
+                f"No RaggedArrays found in args or kwargs of function {fn}"
+            )
         ret = ivy.NestedArray.ragged_multi_map(map_fn, nests)
         return ret
 

--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -1180,7 +1180,7 @@ def _dtype_from_version(dic, version):
 
     # If version dict is empty, then there is an error
     if not dic:
-        raise Exception("No version found in the dictionary")
+        raise ValueError("No version found in the dictionary")
 
     # If key is already in the dictionary, return the value
     if version in dic:

--- a/ivy/functional/backends/mxnet/device.py
+++ b/ivy/functional/backends/mxnet/device.py
@@ -50,7 +50,7 @@ def as_native_dev(device: str, /):
     elif "gpu" in device:
         mx_dev = "gpu"
     else:
-        raise Exception(f"dev input {device} not supported.")
+        raise ValueError(f"dev input {device} not supported.")
     if device.find(":") != -1:
         mx_dev_id = int(device[device.find(":") + 1 :])
     else:

--- a/ivy/functional/backends/paddle/manipulation.py
+++ b/ivy/functional/backends/paddle/manipulation.py
@@ -221,7 +221,7 @@ def stack(
 
     first_shape = arrays[0].shape
     if any(arr.shape != first_shape for arr in arrays):
-        raise Exception("Shapes of all inputs must match")
+        raise ValueError("Shapes of all inputs must match")
     if 0 in first_shape:
         return ivy.empty(
             first_shape[:axis] + [len(arrays)] + first_shape[axis:], dtype=dtype

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1826,7 +1826,7 @@ class Tensor:
 
     def apply_(self, callable, /):
         if self.device != "cpu":
-            raise Exception("apply_ is only supported on cpu tensors")
+            raise ValueError("apply_ is only supported on cpu tensors")
         self.ivy_array = callable(self.ivy_array)
         return self
 

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -158,7 +158,7 @@ def test_function_backend_computation(
     if ("out" in kwargs or test_flags.with_out) and "out" not in inspect.signature(
         getattr(ivy, fn_name)
     ).parameters:
-        raise Exception(f"Function {fn_name} does not have an out parameter")
+        raise RuntimeError(f"Function {fn_name} does not have an out parameter")
 
     # Run either as an instance method or from the API directly
     with BackendHandler.update_backend(fw) as ivy_backend:

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -1208,7 +1208,7 @@ def test_inplace_arrays_supported(backend_fw):
         elif backend_fw in ["jax", "tensorflow", "paddle"]:
             assert not ivy_backend.inplace_arrays_supported()
         else:
-            raise Exception("Unrecognized framework")
+            raise RuntimeError("Unrecognized framework")
 
 
 # inplace_decrement
@@ -1329,7 +1329,7 @@ def test_inplace_variables_supported(backend_fw):
         elif backend_fw in ["jax", "paddle"]:
             assert not ivy_backend.inplace_variables_supported()
         else:
-            raise Exception("Unrecognized framework")
+            raise RuntimeError("Unrecognized framework")
 
 
 # is_array


### PR DESCRIPTION
# PR Description
At some places in the codebase, general exceptions are raised.

https://github.com/unifyai/ivy/blob/1f6264e1be8946b4b142668a0201fbaa73ee0810/ivy/functional/backends/mxnet/device.py#L53
https://github.com/unifyai/ivy/blob/1f6264e1be8946b4b142668a0201fbaa73ee0810/ivy/functional/backends/paddle/manipulation.py#L224
https://github.com/unifyai/ivy/blob/1f6264e1be8946b4b142668a0201fbaa73ee0810/ivy/functional/frontends/torch/tensor.py#L1829

Raising too general exceptions will result in catching exceptions other than the ones we expect to catch. This can hide bugs or make it harder to debug programs when unrelated errors are hidden.

## Related Issue
Closes #27743

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
