### PR TITLE
fix: Fixed arguments in `staticmethod`

### DIFF
--- a/ivy/data_classes/container/experimental/linear_algebra.py
+++ b/ivy/data_classes/container/experimental/linear_algebra.py
@@ -768,7 +768,7 @@ class _ContainerWithLinearAlgebraExperimental(ContainerBase):
 
     @staticmethod
     def static_cond(
-        self: ivy.Container,
+        x: ivy.Container,
         /,
         *,
         key_chains: Optional[Union[List[str], Dict[str, str], ivy.Container]] = None,
@@ -784,7 +784,7 @@ class _ContainerWithLinearAlgebraExperimental(ContainerBase):
 
         Parameters
         ----------
-            self
+            x
                 container with input arrays.
             p
                 order of the norm of the matrix (see ivy.norm).
@@ -803,7 +803,7 @@ class _ContainerWithLinearAlgebraExperimental(ContainerBase):
         """
         return ContainerBase.cont_multi_map_in_function(
             "cond",
-            self,
+            x,
             p=p,
             out=out,
             key_chains=key_chains,


### PR DESCRIPTION
# PR Description
In the following `staticmethod` definition the first argument is used as `self`.
https://github.com/unifyai/ivy/blob/0a7cedeb9feec0ae792589f868d8f59b696395e2/ivy/data_classes/container/experimental/linear_algebra.py#L769-L780
 it should be changed to `x` to follow the recommended way like in other `staticmethods`.

## Related Issue
Closes #27766 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
