### PR TITLE
fix: pin framework versions in optional.txt

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -5,9 +5,9 @@ coverage
 dm-haiku # mod_name=haiku
 flax
 h5py
-hypothesis==6.98.10 # fixed version till this get solved: https://github.com/HypothesisWorks/hypothesis/issues/3896
-jax
-jaxlib
+hypothesis==6.98.10
+jax<=0.4.33
+jaxlib<=0.4.33
 matplotlib
 ml-dtypes # mod_name=ml_dtypes
 networkx
@@ -24,7 +24,7 @@ redis
 scikit-learn # mod_name=sklearn
 scipy
 snakeviz # for profiling
-tensorflow
-torch
-torchvision
+tensorflow<=2.17.0
+torch<=2.4.1
+torchvision<=0.19.1
 xgboost


### PR DESCRIPTION
I guess we should just pin the latest version like this, right @hmahmood24?