### PR TITLE
fixing circular reference bug in `Array.size`

### DIFF
--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -260,7 +260,7 @@ class Array(
     @property
     def size(self) -> Optional[int]:
         """Number of elements in the array."""
-        return ivy.size(self)
+        return ivy.size(self._data)
 
     @property
     def itemsize(self) -> Optional[int]:


### PR DESCRIPTION
Closes #28839 

