### PR TITLE
fixing `ivy.inputs_to_native_arrays` when `array_mode=False`

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -397,8 +397,6 @@ def inputs_to_native_arrays(fn: Callable) -> Callable:
         -------
             The return of the function, with native arrays passed in the arguments.
         """
-        if not ivy.array_mode:
-            return fn(*args, **kwargs)
         # check if kwargs contains an out argument, and if so, remove it
         has_out = False
         out = None


### PR DESCRIPTION
closes #28839