### PR TITLE
Add subtract_ function to paddle frontend math module

### DIFF
--- a/ivy/functional/frontends/paddle/math.py
+++ b/ivy/functional/frontends/paddle/math.py
@@ -639,6 +639,12 @@ def subtract(x, y, name=None):
     return ivy.subtract(x, y)
 
 
+@with_unsupported_dtypes({"2.6.0 and below": ("float16", "bfloat16")}, "paddle")
+@to_ivy_arrays_and_back
+def subtract_(x, y, name=None):
+    return ivy.inplace_update(x, subtract(x, y))
+
+
 @with_supported_dtypes(
     {
         "2.6.0 and below": (

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_math.py
@@ -2570,6 +2570,41 @@ def test_paddle_subtract(
     )
 
 
+# subtract_
+@handle_frontend_test(
+    fn_tree="paddle.subtract_",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        num_arrays=2,
+        allow_inf=False,
+        large_abs_safety_factor=2,
+        small_abs_safety_factor=2,
+        safety_factor_scale="log",
+        shared_dtype=True,
+    ),
+)
+def test_paddle_subtract_(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        fn_tree=fn_tree,
+        test_flags=test_flags,
+        on_device=on_device,
+        x=x[0],
+        y=x[1],
+    )
+
+
 @handle_frontend_test(
     fn_tree="paddle.sum",
     dtype_and_x=helpers.dtype_and_values(


### PR DESCRIPTION
- Implement missing subtract_ function in ivy/ivy/functional/frontends/paddle/math.py
- Add corresponding test case in ivy_tests/test_ivy/test_frontends/test_paddle/test_math.py
- Follows same pattern as other inplace functions like add_
- Uses ivy.inplace_update for in-place subtraction operation
- Fixes issue #21937


 

##  **Summary**

This will create **ONE CLEAN PR** that:
-  Adds the missing `subtract_` function
-  Includes proper test coverage
-  Follows Ivy's established patterns
-  Fixes issue #21937
- Is ready for review and merge

The PR will be clean, focused, and ready for the Ivy team to review! 