### PR TITLE
fix: correct typos in tracer and backend modules

### DIFF
--- a/ivy/tracer/helpers.py
+++ b/ivy/tracer/helpers.py
@@ -409,7 +409,7 @@ def _apply_fn_to_class(cls, fn, fargs, fkwargs, **kwargs):
             except AttributeError:
                 name = "function"
 
-            # Only the constructor is supposed to recieve the args/kwargs
+            # Only the constructor is supposed to receive the args/kwargs
             # when tracing/transpiling entire classes
             if name != "__init__":
                 return MethodDescriptor(inner_function, name, fn, None, None, **kwargs)

--- a/ivy/utils/backend/sub_backend_handler.py
+++ b/ivy/utils/backend/sub_backend_handler.py
@@ -115,13 +115,13 @@ def fn_name_from_version_specific_fn_name_sub_backend(
         )
     else:
         back_version = tuple(map(int, back_version.split(".")))
-    v_occurences = [m.start() for m in re.finditer("_v_", name)]
-    fn_name_1 = name[: v_occurences[1] + 3]
-    fn_name_2 = name[: v_occurences[0]] + name[v_occurences[1] :]
+    v_occurrences = [m.start() for m in re.finditer("_v_", name)]
+    fn_name_1 = name[: v_occurrences[1] + 3]
+    fn_name_2 = name[: v_occurrences[0]] + name[v_occurrences[1] :]
     ret_1 = fn_name_from_version_specific_fn_name(fn_name_1, sub_backend_version)
     ret_2 = fn_name_from_version_specific_fn_name(fn_name_2, backend_version)
     if ret_1 == ret_2:
-        return name[: v_occurences[0]]
+        return name[: v_occurrences[0]]
 
 
 # dynamic sub_backend detection


### PR DESCRIPTION
Fix minor spelling errors:
- `recieve` → `receive` in helpers.py
- `occurences` → `occurrences` in sub_backend_handler.py (4 instances)