### PR TITLE
chore(codeowners): set Yusha + Haris as default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,12 @@
+# CODEOWNERS for unifyai/ivy
+#
+# Default reviewer pair are the two founding engineers; per-path
+# rules below override the default where Ivy's framework-specific
+# expertise applies (CODEOWNERS uses last-match-wins semantics).
+
+# Default reviewers.
+* @YushaArif99 @hmahmood24
+
 # Ivy Framework
 ivy/func_wrapper.py @Sam-Armstrong
 **/gradients.py @Sam-Armstrong


### PR DESCRIPTION
## Summary

Adds (or updates) `.github/CODEOWNERS` so that the two founding engineers — @YushaArif99 and @hmahmood24 — are the default reviewers for all paths in this repo.

Either approval satisfies branch protection. GitHub's automatic author-exclusion rule means that when one of them opens a PR the other becomes the implicit required reviewer — no conditional logic, Action, or auto-assignment workflow needed.

Companion change (to be applied **after this PR merges**): flip `require_code_owner_reviews` to `true` on the `main` branch protection rule, so the code-owner requirement is enforced at merge time, not just used for auto-request.

## Why

Daniel's role is increasingly GTM- and sales-oriented; concentrating default code review on the two founding engineers reflects how engineering responsibility now actually distributes, and gives every PR a clear owner.

## Notes

- Sequencing: this PR must merge before flipping `require_code_owner_reviews=true` on this repo's protection, or the branch would soft-lock (no PR could satisfy the rule because there were no code owners defined on main yet).
- For `ivy` specifically: existing per-path rules to @Sam-Armstrong are preserved as overrides — CODEOWNERS uses last-match-wins, so @Sam-Armstrong remains the owner of the Ivy framework / docs / testing paths he already owned; @YushaArif99 + @hmahmood24 become the default for everything else.
